### PR TITLE
Add Dockerfile and README.md instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.12-alpine AS builder
+# Executable application name
 ARG APP_NAME=code2tutorials
 
 LABEL org.opencontainers.image.authors="samin-irtiza" \
@@ -24,6 +25,7 @@ COPY . /app
 RUN pyinstaller --onefile --name $APP_NAME main.py
 
 FROM alpine:latest
+# Executable application name
 ARG APP_NAME=code2tutorials
 LABEL org.opencontainers.image.authors="samin-irtiza" \
       org.opencontainers.image.title="${APP_NAME}" \
@@ -39,7 +41,6 @@ RUN apk add --no-cache git
 
 RUN chmod +x /app/$APP_NAME
 
-ENV APP_NAME=${APP_NAME}
-
-ENTRYPOINT ["/bin/sh", "-c", "exec /app/$APP_NAME \"$@\"", "--"]
+# Change the entrypoint according to the executable application name. 
+ENTRYPOINT ["/app/code2tutorials"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.12-alpine AS builder
+ARG APP_NAME=code2tutorials
 
 LABEL org.opencontainers.image.authors="samin-irtiza" \
-    description="A Dockerfile for building and running the code2docs application" \
+    description="A Dockerfile for building and running the ${APP_NAME} application" \
     version="1.0"
 
 ENV PYTHONUNBUFFERED=1 \
@@ -18,12 +19,13 @@ RUN apk add --no-cache git patchelf binutils && \
 
 COPY . /app
 
-RUN pyinstaller --onefile --name code2docs main.py
+RUN pyinstaller --onefile --name $APP_NAME main.py
 
 FROM alpine:latest
+ARG APP_NAME=code2tutorials
 
 LABEL org.opencontainers.image.authors="samin-irtiza" \
-    description="A lightweight runtime image for the code2docs application" \
+    description="A lightweight runtime image for the ${APP_NAME} application" \
     version="1.0"
 
 WORKDIR /app
@@ -32,7 +34,9 @@ COPY --from=builder /app/dist /app/
 
 RUN apk add --no-cache git
 
-RUN chmod +x /app/code2docs
+RUN chmod +x /app/$APP_NAME
 
-ENTRYPOINT ["/app/code2docs"]
+ENV APP_NAME=${APP_NAME}
+
+ENTRYPOINT ["/bin/sh", "-c", "/app/$APP_NAME"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM python:3.12-alpine AS builder
 ARG APP_NAME=code2tutorials
 
 LABEL org.opencontainers.image.authors="samin-irtiza" \
-    description="A Dockerfile for building and running the ${APP_NAME} application" \
-    version="1.0"
+      org.opencontainers.image.title="${APP_NAME} Builder" \
+      org.opencontainers.image.description="Build layer for the ${APP_NAME} application, which generates tutorials from codebases." \
+      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.source="https://github.com/The-Pocket/Tutorial-Codebase-Knowledge"
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
@@ -23,10 +25,11 @@ RUN pyinstaller --onefile --name $APP_NAME main.py
 
 FROM alpine:latest
 ARG APP_NAME=code2tutorials
-
 LABEL org.opencontainers.image.authors="samin-irtiza" \
-    description="A lightweight runtime image for the ${APP_NAME} application" \
-    version="1.0"
+      org.opencontainers.image.title="${APP_NAME}" \
+      org.opencontainers.image.description="Runtime layer for the ${APP_NAME} application, a CLI tool for generating tutorials from codebases." \
+      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.source="https://github.com/The-Pocket/Tutorial-Codebase-Knowledge"
 
 WORKDIR /app
 
@@ -38,5 +41,5 @@ RUN chmod +x /app/$APP_NAME
 
 ENV APP_NAME=${APP_NAME}
 
-ENTRYPOINT ["/bin/sh", "-c", "/app/$APP_NAME"]
+ENTRYPOINT ["/bin/sh", "-c", "exec /app/$APP_NAME \"$@\"", "--"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.12-alpine AS builder
+
+LABEL org.opencontainers.image.authors="samin-irtiza" \
+    description="A Dockerfile for building and running the code2docs application" \
+    version="1.0"
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt /app/
+
+RUN apk add --no-cache git patchelf binutils && \
+    pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    pip install pyinstaller
+
+COPY . /app
+
+RUN pyinstaller --onefile --name code2docs main.py
+
+FROM alpine:latest
+
+LABEL org.opencontainers.image.authors="samin-irtiza" \
+    description="A lightweight runtime image for the code2docs application" \
+    version="1.0"
+
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/
+
+RUN apk add --no-cache git
+
+RUN chmod +x /app/code2docs
+
+ENTRYPOINT ["/app/code2docs"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -115,35 +115,31 @@ This is a tutorial project of [Pocket Flow](https://github.com/The-Pocket/Pocket
 
 The application will crawl the repository, analyze the codebase structure, generate tutorial content in the specified language, and save the output in the specified directory (default: ./output).
 
+
 ## 🐳 Run with Docker
 
-You can easily run the application using Docker. Follow these steps:
+1. Navigate to the root directory of the project and build the Docker image:  
+   ```bash
+   docker build -t code2tutorials .
+   ```
 
-1. Build the Docker Image
-Navigate to the root directory of the project and build the Docker image:
-```bash
-docker build -t code2tutorials .
-```
+2. Run the container with the following command:  
+   ```bash
+   docker run -it --rm \
+   -v $(pwd):/app \
+   --env GEMINI_API_KEY=<your-api-key> \
+   code2tutorials --repo https://github.com/username/repo-name
+   ```
 
-2. Run the Docker Container
-Run the container with the following command:
-```bash
-docker run -it --rm \
-  -v $(pwd):/app \
-  --env GEMINI_API_KEY=<your-api-key> \
-  code2tutorials --repo https://github.com/username/repo-name
-```
+3. For easier access, set an alias for the Docker command in your shell configuration file (e.g., `.bashrc` or `.zshrc`):  
+   ```bash
+   alias code2tutorials='docker run -it --rm -v $(pwd):/app --env GEMINI_API_KEY=<your-api-key> code2tutorials'
+   ```
 
-3. Optional: Create a Shell Alias (Linux)
-For easier access, you can set an alias for the Docker command in your shell configuration file (e.g., `.bashrc` or `.zshrc`):
-```bash
-alias code2tutorials='docker run -it --rm -v $(pwd):/app --env GEMINI_API_KEY=<your-api-key> code2tutorials'
-```
-
-After setting the alias, you can run the application with a simplified command:
-```bash
-code2tutorials --repo https://github.com/username/repo-name
-```
+4. After setting the alias, run the application with a simplified command:  
+   ```bash
+   code2tutorials --repo https://github.com/username/repo-name
+   ```
 ## 💡 Development Tutorial
 
 - I built using [**Agentic Coding**](https://zacharyhuang.substack.com/p/agentic-coding-the-most-fun-way-to), the fastest development paradigm, where humans simply [design](docs/design.md) and agents [code](flow.py).

--- a/README.md
+++ b/README.md
@@ -115,6 +115,35 @@ This is a tutorial project of [Pocket Flow](https://github.com/The-Pocket/Pocket
 
 The application will crawl the repository, analyze the codebase structure, generate tutorial content in the specified language, and save the output in the specified directory (default: ./output).
 
+## 🐳 Run with Docker
+
+You can easily run the application using Docker. Follow these steps:
+
+1. Build the Docker Image
+Navigate to the root directory of the project and build the Docker image:
+```bash
+docker build -t code2tutorials .
+```
+
+2. Run the Docker Container
+Run the container with the following command:
+```bash
+docker run -it --rm \
+  -v $(pwd):/app \
+  --env GEMINI_API_KEY=<your-api-key> \
+  code2tutorials --repo https://github.com/username/repo-name
+```
+
+3. Optional: Create a Shell Alias (Linux)
+For easier access, you can set an alias for the Docker command in your shell configuration file (e.g., `.bashrc` or `.zshrc`):
+```bash
+alias code2tutorials='docker run -it --rm -v $(pwd):/app --env GEMINI_API_KEY=<your-api-key> code2tutorials'
+```
+
+After setting the alias, you can run the application with a simplified command:
+```bash
+code2tutorials --repo https://github.com/username/repo-name
+```
 ## 💡 Development Tutorial
 
 - I built using [**Agentic Coding**](https://zacharyhuang.substack.com/p/agentic-coding-the-most-fun-way-to), the fastest development paradigm, where humans simply [design](docs/design.md) and agents [code](flow.py).


### PR DESCRIPTION
This PR enhances the project by enabling the application to be run as a CLI tool using Docker. Users can now easily analyze codebases and generate tutorials without needing to install dependencies locally.

#### Key Updates:
- **Dockerization**: 
  - Builds a lightweight runtime image (**38.1 MB** approximately as of now) for the CLI tool using **PyInstaller** and **Docker**.
  - Ensures the application binary is executable and ready to use.

- **Usage Instructions**:
  - Added steps in the README for building and running the Docker container.
  - Users can pass arguments like `--repo`, `--dir`, and other CLI options directly to the Dockerized application.

#### Benefits:
- Simplifies setup and usage by encapsulating the application in a Docker container.
- Provides a consistent runtime environment for the CLI tool.

Users can now run the application with a single Docker command or set up a shell alias for even easier access.