### PR TITLE
prompt split

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -195,7 +195,7 @@ Format the output as a YAML list of dictionaries:
         for item  in yaml_str_list:
             for c in item.strip().split("```"):
                 if c.strip():
-                    yaml_str += c.strip() +"\n"
+                    yaml_str += c +"\n"
 
         abstractions = yaml.safe_load(yaml_str)
         abstractions = [] if not abstractions else abstractions

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -1,0 +1,39 @@
+import tiktoken, json
+from typing import List, Dict, Iterable
+
+
+MAX_TOKENS = 16000
+SPLIT_TOKENS = MAX_TOKENS * 0.5
+
+def length_of_tokens(prompt, encoding_name: str = "cl100k_base"):
+    enc = tiktoken.get_encoding(encoding_name)
+    all_tokens = enc.encode(prompt, disallowed_special=())
+    return len(all_tokens)
+
+
+def batch_chunks(chunks: List[str], prompt:str = "", params_name:str = "chunk_list_content", extra_vars: Dict[str, str] | None = None) -> Iterable[List[str]]:
+    """
+    将 chunks 切分成若干批，使得 `prompt + batch` 的 token
+    不超过 BATCH_TARGET。
+    """
+    batch: List[str] = []
+    cur_tokens = 0
+    extra_vars = extra_vars or {}
+    param_format= {**extra_vars, params_name: ""}
+    prompt_tokens = length_of_tokens(
+        prompt.format(**param_format)
+    )
+
+    for chunk in chunks:
+        chunk_tokens = length_of_tokens(chunk)
+        if (
+            cur_tokens + chunk_tokens + prompt_tokens > SPLIT_TOKENS
+            and batch
+        ):
+            yield batch
+            batch = []
+            cur_tokens = 0
+        batch.append(chunk)
+        cur_tokens += chunk_tokens
+    if batch:
+        yield batch


### PR DESCRIPTION
Split the prompt to prevent it from becoming too long and triggering token-limit errors.